### PR TITLE
Update NSTool to v1.4.1

### DIFF
--- a/src/MetaProcess.cpp
+++ b/src/MetaProcess.cpp
@@ -448,8 +448,8 @@ void MetaProcess::displayKernelCap(const nn::hac::KernelCapabilityControl& kern)
 			std::cout << "0x" << std::hex << (uint32_t)interupts[i];
 			if (interupts[i] != interupts.atBack())
 				std::cout << ", ";
-			std::cout << std::endl;
 		}
+		std::cout << std::endl;
 	}
 	if (kern.getMiscParams().isSet())
 	{

--- a/src/version.h
+++ b/src/version.h
@@ -3,5 +3,5 @@
 #define BIN_NAME	"nstool"
 #define VER_MAJOR	1
 #define VER_MINOR	4
-#define VER_PATCH   0
+#define VER_PATCH   1
 #define AUTHORS		"jakcron"


### PR DESCRIPTION
# Change Log
* Updated `libnintendo-hac` to v0.5.1. (read more here: https://github.com/jakcron/libnintendo-hac/pull/13)
  * Fixed bug where interrupt kernel capabilities were not imported.
* Fixed formatting issue where kernel interrupts where not displayed properly in `main.npdm` files. 

