### PR TITLE
Update NSTool to v1.8.0 

### DIFF
--- a/.github/workflows/compile_main_branches.yml
+++ b/.github/workflows/compile_main_branches.yml
@@ -1,10 +1,10 @@
-name: Compile Main Branch
+name: Compile Main Branches
 
 on:
   push:
-    branches: [ main ]
+    branches: [ development-tip, stable ]
   pull_request:
-    branches: [ main ]
+    branches: [ development-tip, stable ]
   release:
     types: [ created ]
 

--- a/src/NcaProcess.cpp
+++ b/src/NcaProcess.cpp
@@ -488,22 +488,18 @@ void nstool::NcaProcess::displayHeader()
 	if (mContentKey.kak_list.size() > 0 && mCliOutputMode.show_keydata)
 	{
 		fmt::print("  Key Area:\n");
-		fmt::print("    <--------------------------------------------------------------------------------------------------------->\n");
-		fmt::print("    | IDX | ENCRYPTED KEY                                   | DECRYPTED KEY                                   |\n");
-		fmt::print("    |-----|-------------------------------------------------|-------------------------------------------------|\n");
+		fmt::print("    <--------------------------------------------------------------------------->\n");
+		fmt::print("    | IDX | ENCRYPTED KEY                    | DECRYPTED KEY                    |\n");
+		fmt::print("    |-----|----------------------------------|----------------------------------|\n");
 		for (size_t i = 0; i < mContentKey.kak_list.size(); i++)
 		{
-			fmt::print("    | {:3d} | {:s} | ", mContentKey.kak_list[i].index, tc::cli::FormatUtil::formatBytesAsString(mContentKey.kak_list[i].enc.data(), mContentKey.kak_list[i].enc.size(), true, ""));
-						
+			std::string enc_key = tc::cli::FormatUtil::formatBytesAsString(mContentKey.kak_list[i].enc.data(), mContentKey.kak_list[i].enc.size(), true, "");
+			std::string dec_key = mContentKey.kak_list[i].decrypted ? tc::cli::FormatUtil::formatBytesAsString(mContentKey.kak_list[i].dec.data(), mContentKey.kak_list[i].dec.size(), true, "") : "<unable to decrypt>";
 			
-			if (mContentKey.kak_list[i].decrypted)
-				fmt::print("{:s}", tc::cli::FormatUtil::formatBytesAsString(mContentKey.kak_list[i].dec.data(), mContentKey.kak_list[i].dec.size(), true, ""));
-			else
-				fmt::print("<unable to decrypt>                            ");
-			
-			fmt::print(" |\n");
+			fmt::print("    | {:3d} | {:32s} | {:32s} |\n", mContentKey.kak_list[i].index, enc_key, dec_key);
+		
 		}
-		fmt::print("    <--------------------------------------------------------------------------------------------------------->\n");
+		fmt::print("    <--------------------------------------------------------------------------->\n");
 	}
 
 	if (mCliOutputMode.show_layout)

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 #define APP_NAME	"NSTool"
 #define BIN_NAME	"nstool"
-#define VER_MAJOR	1
-#define VER_MINOR	7
+#define VER_MAJOR	0
+#define VER_MINOR	0
 #define VER_PATCH   0
 #define AUTHORS		"jakcron"

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 #define APP_NAME	"NSTool"
 #define BIN_NAME	"nstool"
-#define VER_MAJOR	0
-#define VER_MINOR	0
+#define VER_MAJOR	1
+#define VER_MINOR	8
 #define VER_PATCH   0
 #define AUTHORS		"jakcron"


### PR DESCRIPTION
# Changes
* [BugFix] Fixed issue where NCA ContentType was not correctly reported (#95)
* [BugFix] Fixed issue NSO Data Segment was not processed correctly because state for Data Segment incorrectly tested RO Segment flags
* [BugFix] Fixed issue where Brazilian Portuguese languages in NACP where not identified as Brazilian Portuguese
* [BugFix] Fixed issue where debug logging was left in for when empty RomFs files were processed.
* [BugFix] Fixed issue where NCA key area was not formatted correctly (#91) 

# Nerd details
* [Dependency] libpietendo to v0.7.1.