### PR TITLE
Add support for specifying multiple tickets / title keys

### DIFF
--- a/SWITCH_KEYS.md
+++ b/SWITCH_KEYS.md
@@ -203,4 +203,18 @@ nstool <32 char rightsid>.tik
 ##### Personalised Tickets
 If the ticket is personalised (encrypted with console unique RSA key), NSTool will not support it. You will need to use extract the title key with another tool and pass the encrypted title key directly with the `--titlekey` option.
 
-# Title
+# Title Keys (title.keys)
+In order for NSTool to decrypt NCA files that use external content keys, the ticket or key data be provided to NSTool. For convience NSTool supports the hactool `title.keys` format. This file can store a dictionary of title keys, so that specifying a ticket or key data manually is not required, provided it is present in `title.keys`. This file must be present in: ___$HOME/.switch/___ .
+
+## Format
+* This file is in the format of (rights_id, title_key) pairs, each on their own line. 
+* There is no limit on the number of pairs. 
+* The `;` is the comment indicator. When parsing a file, it is treated as a new line character.
+* The format is case insensitive
+
+
+### Example
+For example if rights id `010003000e1468000000000000000008` had a title key `8fa820b219781d331cca08968e6e5b52`, the row would look like this:
+```
+010003000e1468000000000000000008 = 8fa820b219781d331cca08968e6e5b52
+```

--- a/SWITCH_KEYS.md
+++ b/SWITCH_KEYS.md
@@ -207,7 +207,7 @@ If the ticket is personalised (encrypted with console unique RSA key), NSTool wi
 In order for NSTool to decrypt NCA files that use external content keys, the ticket or key data be provided to NSTool. For convience NSTool supports the hactool `title.keys` format. This file can store a dictionary of title keys, so that specifying a ticket or key data manually is not required, provided it is present in `title.keys`. This file must be present in: ___$HOME/.switch/___ .
 
 ## Format
-* This file is in the format of (rights_id, title_key) pairs, each on their own line. 
+* This file is in the format of (rights_id = title_key) pairs, each on their own line. 
 * There is no limit on the number of pairs. 
 * The `;` is the comment indicator. When parsing a file, it is treated as a new line character.
 * The format is case insensitive

--- a/src/KeyBag.cpp
+++ b/src/KeyBag.cpp
@@ -470,7 +470,8 @@ void nstool::KeyBagInitializer::importTitleKeyFile(const tc::io::Path& keyfile_p
 		tmp = tc::cli::FormatUtil::hexStringToBytes(itr->first);
 		if (tmp.size() != rights_id_tmp.size())
 		{
-			throw tc::ArgumentException("nstool::KeyBagInitializer", "RightsID: \"" + itr->first + "\" has incorrect length");
+			fmt::print("[nstool::KeyBagInitializer WARNING] RightsID: \"{}\" has incorrect length. Skipping...\n", itr->first);
+			continue;
 		}
 		memcpy(rights_id_tmp.data(), tmp.data(), rights_id_tmp.size());
 
@@ -478,7 +479,8 @@ void nstool::KeyBagInitializer::importTitleKeyFile(const tc::io::Path& keyfile_p
 		tmp = tc::cli::FormatUtil::hexStringToBytes(itr->second);
 		if (tmp.size() != title_key_tmp.size())
 		{
-			throw tc::ArgumentException("nstool::KeyBagInitializer", "TitleKey for \""+ itr->first + "\": \"" + itr->second + "\" has incorrect length");
+			fmt::print("[nstool::KeyBagInitializer WARNING] TitleKey for \"{}\": \"{}\" has incorrect length. Skipping...\n", itr->first, itr->second);
+			continue;
 		}
 		memcpy(title_key_tmp.data(), tmp.data(), title_key_tmp.size());
 

--- a/src/KeyBag.h
+++ b/src/KeyBag.h
@@ -39,6 +39,7 @@ struct KeyBag
 
 	// external content keys (nca<->ticket)
 	std::map<rights_id_t, aes128_key_t> external_content_keys;
+	std::map<rights_id_t, aes128_key_t> external_enc_content_keys; // encrypted content key list to be used when external_content_keys does not have the required content key (usually taken raw from ticket)
 	tc::Optional<aes128_key_t> fallback_enc_content_key; // encrypted content key to be used when external_content_keys does not have the required content key (usually taken raw from ticket)
 	tc::Optional<aes128_key_t> fallback_content_key; // content key to be used when external_content_keys does not have the required content key (usually already decrypted from ticket)
 
@@ -70,7 +71,7 @@ struct KeyBag
 class KeyBagInitializer : public KeyBag
 {
 public:
-	KeyBagInitializer(bool isDev, const tc::Optional<tc::io::Path>& keyfile_path, const tc::Optional<tc::io::Path>& tik_path, const tc::Optional<tc::io::Path>& cert_path);
+	KeyBagInitializer(bool isDev, const tc::Optional<tc::io::Path>& keyfile_path, const tc::Optional<tc::io::Path>& titlekeyfile_path, const std::vector<tc::io::Path>& tik_path_list, const tc::Optional<tc::io::Path>& cert_path);
 private:
 	KeyBagInitializer();
 

--- a/src/NcaProcess.cpp
+++ b/src/NcaProcess.cpp
@@ -176,6 +176,15 @@ void nstool::NcaProcess::generateNcaBodyEncryptionKeys()
 		{
 			mContentKey.aes_ctr = mKeyCfg.fallback_content_key.get();
 		}
+		else if (mKeyCfg.external_enc_content_keys.find(mHdr.getRightsId()) != mKeyCfg.external_enc_content_keys.end())
+		{
+			tmp_key = mKeyCfg.external_enc_content_keys[mHdr.getRightsId()];
+			if (mKeyCfg.etik_common_key.find(masterkey_rev) != mKeyCfg.etik_common_key.end())
+			{
+				pie::hac::AesKeygen::generateKey(tmp_key.data(), tmp_key.data(), mKeyCfg.etik_common_key[masterkey_rev].data());
+				mContentKey.aes_ctr = tmp_key;
+			}
+		}
 		else if (mKeyCfg.fallback_enc_content_key.isSet())
 		{
 			tmp_key = mKeyCfg.fallback_enc_content_key.get();

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -136,10 +136,14 @@ private:
 	bool mVerbose;
 
 	tc::Optional<tc::io::Path> mKeysetPath;
+	tc::Optional<tc::io::Path> mTitleKeysetPath;
 	tc::Optional<KeyBag::aes128_key_t> mNcaEncryptedContentKey;
 	tc::Optional<KeyBag::aes128_key_t> mNcaContentKey;
-	tc::Optional<tc::io::Path> mTikPath;
+	std::vector<tc::io::Path> mTikPathList;
+	//tc::Optional<tc::io::Path> mTikPath;
 	tc::Optional<tc::io::Path> mCertPath;
+
+	void loadKeyFile(tc::Optional<tc::io::Path>& keyfile_path, const std::string& keyfile_name, const std::string& cli_hint);
 
 	bool determineValidNcaFromSample(const tc::ByteData& raw_data) const;
 	bool determineValidEsCertFromSample(const tc::ByteData& raw_data) const;


### PR DESCRIPTION
In order to address https://github.com/jakcron/nstool/issues/106 which arose from the base title and patch title using different tickets. I implemented the following:
* [Change] CLI argument `--tik` can now be used multiple times to import multiple tickets
* [Added] hactool `title.keys` format is now supported. Long standing issue that improves the usability of NSTool as this is a popular format for dumping title keys from a console, and supplying them to other tools.

Documentation was updated to reference that title.keys is now supported.